### PR TITLE
Add intro text to About section

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,22 @@
           to hear what ghosts have on their minds and assist in settling their unfinished business.
           So if you have a ghost you'd like helped into the side other, give us a call!</p>
         <p>
+          These are exciting times for Joss, as she's just been contacted by a big company
+          who wants to sponsor her show! Over the next month, she needs to rack up as many
+          viewers as possible in order to impress them. She'll have to up her game, because
+          we all know that the BooTube crowd isn't a forgiving one...
+        </p>
+        <p>
+          It’s a tricky balance to find: people want drama, drama, drama, until suddenly
+          they think you sound fake. And sometimes, the ghosts’ requests are just so boring…
+          So if Joss plays fast and loose with her interpretation, no one has to know, right?
+          Especially not that sucker from Spectral Self-Help who’s also sniffing around
+          trying to find something to bring Ghost Whisperer down...
+        </p>
+        <P>
+          Anyway, time to meet some ghosts!
+        </p>
+        <p>
           Disclaimer: Please be aware that we do not censor the stories or vocabulary of our guests.
           Some episodes might contain swearing. And obviously, all of them contain dead individuals.
           We do not guarantee your ghost will move on.

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
         </p>
         <p>Equipped with her trusted ghost interpreter, Joss travels across the country
           to hear what ghosts have on their minds and assist in settling their unfinished business.
-          So if you have a ghost you'd like helped into the side other, give us a call!</p>
+          So if you have a ghost you'd like helped into the other side, give us a call!</p>
         <p>
           These are exciting times for Joss, as she's just been contacted by a big company
           who wants to sponsor her show! Over the next month, she needs to rack up as many


### PR DESCRIPTION
This is a quick fix for a missing screen with introduction information. I rewrote the introduction in 3rd person and added it to the About section on the title page